### PR TITLE
Update docs about listing inputs

### DIFF
--- a/docs-src/docs/kognic-io/pre_annotations.md
+++ b/docs-src/docs/kognic-io/pre_annotations.md
@@ -31,7 +31,7 @@ The interface for creating just a scene, without an input, is the same as we are
 The exception is that by not providing a project or a batch in the function call, the scene will be "dangling" until deemed ready for annotation
 
 ```python reference
-https://github.com/annotell/kognic-io-examples-python/blob/master/examples/lidars_and_cameras_seq_with_pre_annotations.py#L82-L83
+https://github.com/annotell/kognic-io-examples-python/blob/master/examples/lidars_and_cameras_seq_with_pre_annotations.py#L83-L84
 ```
 
 ### 2. Uploading an OpenLabel annotation

--- a/docs-src/docs/kognic-io/working_with_scenes_and_inputs.md
+++ b/docs-src/docs/kognic-io/working_with_scenes_and_inputs.md
@@ -165,7 +165,7 @@ The response is a list of `Input` objects containing the following properties
 | Property         | Description                                                                                          |
 |------------------|------------------------------------------------------------------------------------------------------|
 | uuid             | ID used to identify the input within the Kognic Platform                                             |
-| scene_uuid       | ID used to identify the scene that the input using                                                   |
+| scene_uuid       | ID used to identify the scene that the input is using                                                   |
 | request_uid      | ID used to identify the request that the input belongs to                                            |
 | view_link        | A url to view the input in the Kognic Platform                                                       |
 

--- a/docs-src/docs/kognic-io/working_with_scenes_and_inputs.md
+++ b/docs-src/docs/kognic-io/working_with_scenes_and_inputs.md
@@ -138,49 +138,38 @@ The response is a list of `Scene` objects containing the following properties
 | view_link      | A url to view the scene in the Kognic Platform                                                       |
 | error_message  | If there is an error during scene creation the error message will be included, otherwise it's `None` |
 
-
 ## List Inputs
 
+:::note
+This feature is new in version 1.7.0
+:::
 
-Inputs can be retrieved from the API in two ways:
-1. Filtering on a project using the `get_inputs` method. Additional filter parameters are also available 
-   (see table below) for querying inputs.
-2. Providing the input uuids of the inputs to be retrieved using the `get_inputs_by_uuids` method
+Inputs can be queried from the platform using the `query_inputs` method, which can be used in the following way
 
-```python
-# List all inputs for a project
-client.input.get_inputs(project="project-identifier")
-
-# List all inputs for a project and a batch
-client.input.get_inputs(project="project-identifier", batch="batch-identifier") 
-
-# List all inputs for specific input uuids
-input_uuids = ['cca60a67-cb68-4645-8bae-00c6e6415555', 'cc8776d0-f537-4094-8b11-8c2111741e2f', ...]
-client.input.get_inputs_by_uuids(input_uuids=input_uuids)
+```python reference
+https://github.com/annotell/kognic-io-examples-python/blob/master/examples/query_inputs.py#L6-L10
 ```
 
-Additional filter parameters for querying inputs using `get_inputs` are listed below.
+Additional filter parameters for querying inputs are listed below.
 
-| Parameter           | Description                                               |
-|---------------------|-----------------------------------------------------------|
-| project             | Project identifier to filter by                           |
-| batch               | Which batch in the project to return inputs for           |
-| external_ids        | Return inputs matching the `external_ids` supplied        |
-| include_invalidated | Filters inputs based on their status, defaults to `False` |
+| Parameter    | Description                                                     |
+|--------------|-----------------------------------------------------------------|
+| project      | Project identifier to filter by                                 |
+| batch        | Which batch in the project to return inputs for                 |
+| scene_uuids  | Return inputs using scenes matching the supplied uuids          |
+| external_ids | Return inputs using scenes matching the supplied `external_ids` |
 
 ### Response
 The response is a list of `Input` objects containing the following properties
 
 | Property         | Description                                                                                          |
 |------------------|------------------------------------------------------------------------------------------------------|
-| scene_uuid       | ID used to identify the scene within the Kognic Platform                                             |
-| external_id      | External ID supplied during scene creation                                                           |
-| batch            | Which batch does the input belong to                                                                 |
+| uuid             | ID used to identify the input within the Kognic Platform                                             |
+| scene_uuid       | ID used to identify the scene that the input using                                                   |
+| request_uid      | ID used to identify the request that the input belongs to                                            |
 | view_link        | A url to view the input in the Kognic Platform                                                       |
-| scene_type       | Type of input (see [Scene Types](../key_concepts.md))                                                |
-| status           | Scene status (see [Scene Statuses](#scene-status))                                                   |
-| error_message    | If there is an error during scene creation the error message will be included, otherwise it's `None` |
-| annotation_types | List of annotation types for the scene                                                               |
+
+
 
 ## Invalidate Scenes
 


### PR DESCRIPTION
I was considering whether to remove the old docs or keep it and mark it as deprecated. I decided to go for removing it since it will since I think it will incentivise users to migrate. One thing that's apparent is that we don't have any method to get inputs by uuids which would make a lot of sense to have