### PR TITLE
Document proxy config

### DIFF
--- a/docs-src/docs/dataset-refinement/introduction.md
+++ b/docs-src/docs/dataset-refinement/introduction.md
@@ -12,7 +12,7 @@ Before you begin, make sure you have:
 
 * Access to the refinement tool
 * An account with permissions to use our API
-* Generated API credentials. See [API Credentials](../kognic_auth.md/#generating-credentials)
+* Generated API credentials. See [API Credentials](../kognic_apis.md/#generating-credentials)
 * Installed our Python 3 SDK for authentication - [kognic-auth](https://pypi.org/project/kognic-auth/)
 
 ## No API Client Available

--- a/docs-src/docs/kognic-io/FAQ.md
+++ b/docs-src/docs/kognic-io/FAQ.md
@@ -6,7 +6,7 @@ description: FAQ
 
 ### Receiving `requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: ...` when trying to create inputs
 
-This implies that the authenticated user does not have access to the endpoint being called. Make sure you're [authenticating](../kognic-auth) correctly. If a Kognic user, make sure `client_organization_id` is specified on the `KognicIOClient`.
+This implies that the authenticated user does not have access to the endpoint being called. Make sure you're [authenticating](../kognic-apis#authentication) correctly. If a Kognic user, make sure `client_organization_id` is specified on the `KognicIOClient`.
 
 
 ### How do I know that my input was created successfully?

--- a/docs-src/docs/kognic-io/coordinate_systems.md
+++ b/docs-src/docs/kognic-io/coordinate_systems.md
@@ -7,7 +7,7 @@ different instants in time. This is done by transforming the recordings with sen
 the ego motion data. This section describes how this is done in 3D space and provides a summary about the coordinate 
 systems that different kinds of data is expressed in. For camera sensors, we also need to be able to map
 3D points to pixel coordinates in 2D. This is done using intrinsic parameters of the camera and these vary depending
-on the type of the camera. Refer to [camera calibrations](./calibrations.md#camera) for more information about this.
+on the type of the camera. Refer to [camera calibrations](./calibrations/cameras-standard.md) for more information about this.
 
 ## The reference coordinate system and calibrations
 

--- a/docs-src/docs/kognic-io/overview.md
+++ b/docs-src/docs/kognic-io/overview.md
@@ -83,7 +83,7 @@ Any scene consisting of lidar and camera sensors requires a calibration. The cal
 
 This information is used by the annotation tool to highlight regions in the point cloud visible in the selected camera sensors as well as for projecting information from the pointcloud onto the different camera sensors (points, cuboids etc).
 
-Detailed documentation on how to create calibrations via the API is present in the [Calibration section](calibrations).
+Detailed documentation on how to create calibrations via the API is present in the [Calibration section](./calibrations/overview.md).
 
 When including calibration id make sure that all sensors present on the scene are also present in the calibration as well. If this is not the case the scene will not be created and a validation error will be returned by the API.
 

--- a/docs-src/docs/kognic_apis.md
+++ b/docs-src/docs/kognic_apis.md
@@ -49,6 +49,9 @@ The credentials file, including the Kognic client ID and the Kognic client secre
 
 If your organizations' network policy requires HTTP(S) traffic to be proxied out via a specific host, then you should configure this via your OS or execution environment. `kognic-io` uses Python's `urllib` which [will pick up the proxy configuration from your OS and environment variables](https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies).
 
+The correct proxy host/address to use depends on the network configuration within your organization, so reach out to your internal IT support for details.
+
+For example:
 ```
 export HTTPS_PROXY='http://10.9.8.7:1234'
 ```

--- a/docs-src/docs/kognic_apis.md
+++ b/docs-src/docs/kognic_apis.md
@@ -1,8 +1,14 @@
 ---
-id: kognic-auth
-title: Kognic Auth
-description: How to authenticate with Kognic APIs
+id: kognic-apis
+title: Kognic APIs
+description: Overview of Kognic API usage including authentication
 ---
+
+# API Client Overview
+
+Kognic provides HTTP APIs to our client-facing services, and an API client library ([`kognic-io`](https://pypi.org/project/kognic-io/)), to wrap basic API calls and simplify calling the APIs from Python code.
+
+## Authentication
 Authentication is handled by [kognic-auth](https://pypi.org/project/kognic-auth/), a Python 3 library providing foundations for Kognic Authentication on top of the requests library.
 
 The authentication builds on the standard Oauth 2.0 Client Credentials flow. There are a few ways to provide auth credentials to our api clients. Kognic Python clients such as in  kognic-query or kognic-io accept an auth parameter that can be set explicitly or you can omit it and use environment variables.
@@ -38,3 +44,11 @@ The credentials file, including the Kognic client ID and the Kognic client secre
 
 ![Generate API credentials app screenshot](../static/img/generate-api-credentials.png)
 
+
+## Proxy Configuration
+
+If your organizations' network policy requires HTTP(S) traffic to be proxied out via a specific host, then you should configure this via your OS or execution environment. `kognic-io` uses Python's `urllib` which [will pick up the proxy configuration from your OS and environment variables](https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies).
+
+```
+export HTTPS_PROXY='http://10.9.8.7:1234'
+```

--- a/docs-src/sidebars.js
+++ b/docs-src/sidebars.js
@@ -1,6 +1,6 @@
 module.exports = {
   docs: {
-    "Kognic Auth": ["kognic-auth"],
+    "Kognic APIs": ["kognic-apis"],
     "Key Concepts": ["key_concepts"],
     "Kognic IO": [
       "kognic-io/project",


### PR DESCRIPTION
Adds info about how proxy settings are detected/how to set them via env vars.

Also fixes some broken links between camera and calibration pages so that the build will pass.