### PR TITLE
Fix h2 margins within a summary tag

### DIFF
--- a/docs-src/docs/upload-your-first-scene.mdx
+++ b/docs-src/docs/upload-your-first-scene.mdx
@@ -29,7 +29,7 @@ You have successfully followed the [Quickstart](./quickstart.mdx) guide and have
 
 <details>
   <summary>
-    <h2>Uploading a 2D scene</h2>
+    <h2 style={{margin: '0px'}}>Uploading a 2D scene</h2>
   </summary>
 
 To upload a 2D scene, you need to have the raw images available on your local machine (or create a [callback](https://developers.kognic.com/docs/kognic-io/overview#data-from-callback) for remote data).
@@ -66,7 +66,7 @@ This is often useful when uploading large scenes that take some time to process.
 
 <details>
   <summary>
-    <h2>Uploading a 2D/3D scene</h2>
+    <h2 style={{margin: '0px'}}>Uploading a 2D/3D scene</h2>
   </summary>
 
 To upload a 2D/3D scene, you need to have the raw images and point clouds available on your local machine (or create a [callback](https://developers.kognic.com/docs/kognic-io/overview#data-from-callback) for remote data).


### PR DESCRIPTION
Unfortunately it's impossible to target the h2 element inside a details and summary tag. They seem to be overridden by Docosaurus css no matter what. I unfortunately had to use inline styling to make this work. I'm sorry 