### PR TITLE
Move last three sidebar items to bottom of sidebar

### DIFF
--- a/docs-src/src/css/custom.css
+++ b/docs-src/src/css/custom.css
@@ -63,12 +63,12 @@ article div details[class^="details"] {
   }
 }
 
-/* Better sidebar { */
+/* Better sidebar  */
 .menu a.menu__link {
   margin-top: 0px;
   margin-bottom: 0px;
   font-size: 14px;
-  font-weight: bold;
+  /* font-weight: bold; */
 }
 
 html[data-theme="dark"] .menu a.menu__link {
@@ -82,4 +82,25 @@ html[data-theme="dark"] .menu a.menu__link {
   font-weight: normal;
   text-transform: none;
 }
-/* } */
+
+/* Sidebar container */
+nav ul.theme-doc-sidebar-menu {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* All items except the last three in sidebar */
+.menu ul li.theme-doc-sidebar-item-category:not(:nth-last-child(-n + 3)) {
+  font-weight: bold;
+}
+
+/* Third item from bottom in sidebar */
+.menu ul li.theme-doc-sidebar-item-category:nth-last-of-type(3) {
+  margin-top: auto;
+}
+
+/* Last item in sidebar */
+.menu ul li.theme-doc-sidebar-item-category:nth-last-of-type(1) {
+  margin-bottom: 32px;
+}


### PR DESCRIPTION
Motivation: declutter sidebar and move less frequently used pages to the bottom.

Before:
![Screenshot 2024-11-27 at 16 20 31](https://github.com/user-attachments/assets/7be92138-2663-4a2f-8f7d-bf21eab05db9)

After:
<img width="308" alt="Screenshot 2024-11-27 at 16 20 38" src="https://github.com/user-attachments/assets/d8cb810c-6708-4680-b7da-9bf04956e23f">
